### PR TITLE
SCP-500 pill fix

### DIFF
--- a/Server/Tools/Gamemodes/Breach/players.as
+++ b/Server/Tools/Gamemodes/Breach/players.as
@@ -1453,6 +1453,12 @@ namespace PlayerCallbacks
 			p.SendMessage("msg::aid.stopall", 6.0, true);
 			return false;
 		}
+		if (item.GetTemplateIndex() == it_scp500pill)
+		{
+			p.SetInjuries(0.0);
+			p.SetBloodloss(0.0);
+			p.Console("heal");
+		}
 		return true;
 	}
 	void OnUse914(Player p, int setting)


### PR DESCRIPTION
Here is SCP-500 in multiplayer mode does not work like real SCP-500-01 (heal HP and effects from SCPs). I made a fix for that. Now SCP-500-01 can heal a picker.